### PR TITLE
Innertext regex replace

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           dotnet version: 5.0.x
       - name: Install dependencies
-        run: dotnet restore
+        run: dotnet restore ./Assignment1/
       - name: Build 
         run: dotnet build --configuration Release --no-restore
       - name: Test

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -20,6 +20,6 @@ jobs:
       - name: Install dependencies
         run: dotnet restore ./Assignment1/
       - name: Build 
-        run: dotnet build --configuration Release --no-restore
+        run: dotnet build --configuration Release --no-restore ./Assignment1/
       - name: Test
-        run: dotnet test --no-restore --verbosity normal
+        run: dotnet test --no-restore --verbosity normal ./Assignment1/

--- a/Assignment1/Assignment1.Tests/IteratorsTests.cs
+++ b/Assignment1/Assignment1.Tests/IteratorsTests.cs
@@ -22,5 +22,25 @@ namespace Assignment1.Tests
             // Assert
             Assert.Equal(expectedList, output);
         }
+
+        [Fact]
+        public void Filter_get_1_2_3_4_andEvenPredicateReturn_2_4()
+        {
+            // Arrange
+            var input = new List<int>{1,2,3,4};
+            var expectedOutput = new List<int>{2,4};
+            Predicate<int> even = Even;
+
+            // Act
+            var output = Iterators.Filter(input, Even);
+
+            // Assert
+            Assert.Equal(expectedOutput, output);
+        } 
+
+        public static bool Even(int i)
+        {
+            return i % 2 == 0;
+        }
     }
 }

--- a/Assignment1/Assignment1.Tests/IteratorsTests.cs
+++ b/Assignment1/Assignment1.Tests/IteratorsTests.cs
@@ -1,8 +1,26 @@
 using Xunit;
+using System;
+using System.Collections.Generic;
 
 namespace Assignment1.Tests
 {
     public class IteratorsTests
     {
+        [Fact]
+        public void Flatten_get2by2T_return4T() 
+        {
+            // Arrange
+            var list1 = new List<char>{'T','T'};
+            var list2 = new List<char>{'T','T'};
+            var lists = new List<List<char>>{list1,list2};
+
+            var expectedList = new List<char>{'T','T','T','T'};
+
+            // Act
+            var output = Iterators.Flatten(lists);
+
+            // Assert
+            Assert.Equal(expectedList, output);
+        }
     }
 }

--- a/Assignment1/Assignment1.Tests/RegExprTests.cs
+++ b/Assignment1/Assignment1.Tests/RegExprTests.cs
@@ -1,8 +1,24 @@
+using System.Collections.Generic;
 using Xunit;
 
 namespace Assignment1.Tests
 {
     public class RegExprTests
     {
+        [Fact]
+        public void given2LinesReturns6words() {
+            // Arrange
+            var firstLine = "jeg er mikki";
+            var secondLine = "mikki er jeg";
+            var input = new List<string> {firstLine, secondLine};
+
+            var expectedOutput = new List<string> {"jeg", "er", "mikki", "mikki", "er", "jeg"};
+
+            // Act
+            var output = RegExpr.SplitLine(input);
+
+            // Assert
+            Assert.Equal(expectedOutput, output);
+        }
     }
 }

--- a/Assignment1/Assignment1.Tests/RegExprTests.cs
+++ b/Assignment1/Assignment1.Tests/RegExprTests.cs
@@ -37,6 +37,37 @@ namespace Assignment1.Tests
             Assert.Equal(expectedOutput, output); 
         }
 
+    
+        [Fact]
+        public void InnerText_given_sample_string_from_assignment_returns_only_content_of_a_tags()
+        {
+            //Arrange
+            var input = "<div><p>A <b>regular expression</b>, <b>regex</b> or <b>regexp</b> (sometimes called a <b>rational expression</b>) is, in <a href=\"/wiki/Theoretical_computer_science\" title=\"Theoretical computer science\">theoretical computer science</a> and <a href=\"/wiki/Formal_language\" title=\"Formal language\">formal language</a> theory, a sequence of <a href=\"/wiki/Character_(computing)\" title=\"Character (computing)\">characters</a> that define a <i>search <a href=\"/wiki/Pattern_matching\" title=\"Pattern matching\">pattern</a></i>. Usually this pattern is then used by <a href=\"/wiki/String_searching_algorithm\" title=\"String searching algorithm\">string searching algorithms</a> for \"find\" or \"find and replace\" operations on <a href=\"/wiki/String_(computer_science)\" title=\"String (computer science)\">strings</a>.</p></div>";
+            var expectedOutput = new List<string>{"theoretical computer science", "formal language", "characters", "pattern", "string searching algorithms", "strings"};
+
+            //Act
+            var output = RegExpr.InnerText(input, "a");
+
+
+            //Assert
+            Assert.Equal(expectedOutput, output);
+        }
+
+
+        [Fact]
+        public void InnerText_given_nested_sample_html_returns_all_innertext_without_tags()
+        {
+            //Arrange
+            var input = "<div><p>The phrase <i>regular expressions</i> (and consequently, regexes) is often used to mean the specific, standard textual syntax for representing <u>patterns</u> that matching <em>text</em> need to conform to.</p></div>";
+            var expectedOutput = new List<string>{"The phrase regular expressions (and consequently, regexes) is often used to mean the specific, standard textual syntax for representing patterns that matching text need to conform to."};
+
+            //Act
+            var output = RegExpr.InnerText(input, "p");
+
+            //Assert
+            Assert.Equal(expectedOutput, output);
+        }
+    
     }
 
 

--- a/Assignment1/Assignment1.Tests/RegExprTests.cs
+++ b/Assignment1/Assignment1.Tests/RegExprTests.cs
@@ -1,3 +1,4 @@
+using System; 
 using System.Collections.Generic;
 using Xunit;
 
@@ -20,5 +21,23 @@ namespace Assignment1.Tests
             // Assert
             Assert.Equal(expectedOutput, output);
         }
+    
+        [Fact]
+        public void Resolution_given_1_string_of_8_resolutions_returns_8_tuples()
+        {
+            //Arrange 
+            var input = "1920x1080 1024x768, 800x600, 640x480 320x200, 320x240, 800x600 1280x960";
+            var expectedOutput = new List<(int, int)>{(1920, 1080), (1024, 768), (800, 600), (640, 480), (320, 200), (320, 240), (800, 600), (1280, 960)};
+
+            //Act 
+            var output = RegExpr.Resolution(input);
+
+
+            //Assert
+            Assert.Equal(expectedOutput, output); 
+        }
+
     }
+
+
 }

--- a/Assignment1/Assignment1/Iterators.cs
+++ b/Assignment1/Assignment1/Iterators.cs
@@ -18,7 +18,12 @@ namespace Assignment1
 
         public static IEnumerable<T> Filter<T>(IEnumerable<T> items, Predicate<T> predicate)
         {
-            throw new NotImplementedException();
+            foreach (var item in items)
+            {
+                if (predicate(item)) {
+                    yield return item;
+                } 
+            }
         }
     }
 }

--- a/Assignment1/Assignment1/Iterators.cs
+++ b/Assignment1/Assignment1/Iterators.cs
@@ -7,7 +7,13 @@ namespace Assignment1
     {
         public static IEnumerable<T> Flatten<T>(IEnumerable<IEnumerable<T>> items)
         {
-            throw new NotImplementedException();
+            foreach (var list in items)
+            {
+                foreach (var item in list) 
+                {
+                    yield return item;
+                }
+            }
         }
 
         public static IEnumerable<T> Filter<T>(IEnumerable<T> items, Predicate<T> predicate)

--- a/Assignment1/Assignment1/RegExpr.cs
+++ b/Assignment1/Assignment1/RegExpr.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using System.ComponentModel.DataAnnotations;
 using System.Text.RegularExpressions;
 using System;
 using System.Collections.Generic;
@@ -19,7 +21,16 @@ namespace Assignment1
 
         public static IEnumerable<(int width, int height)> Resolution(string resolutions)
         {
-            throw new NotImplementedException();
+            //(?<vertical>\d+)(?:x)(?<horizontal>\d+)
+            foreach (var line in resolutions)
+            {
+                foreach (var word in Regex.Matches(line, @"(?<horizontal>\d+)(?:x)(?<vertical>\d+)"))
+                {
+                    Console.WriteLine(word);
+                    yield return Int32.Parse(word);
+                    //yield return word;
+                } 
+            }
         }
 
         public static IEnumerable<string> InnerText(string html, string tag)

--- a/Assignment1/Assignment1/RegExpr.cs
+++ b/Assignment1/Assignment1/RegExpr.cs
@@ -35,7 +35,7 @@ namespace Assignment1
             string pattern = @"(?:<"+temp+".*?)(?<=>)(?:<.+>)*(?<text>.*?)(?:</.+>)*(?=</\\k<tag>)";  
             foreach (Match match in Regex.Matches(html, pattern)) 
             {
-                yield return match.Groups["text"].Value;
+                yield return Regex.Replace(match.Groups["text"].Value, @"(<.+?>)", "");
             }
         }
     

--- a/Assignment1/Assignment1/RegExpr.cs
+++ b/Assignment1/Assignment1/RegExpr.cs
@@ -21,19 +21,22 @@ namespace Assignment1
 
         public static IEnumerable<(int width, int height)> Resolution(string resolutions)
         {
-            //(?<vertical>\d+)(?:x)(?<horizontal>\d+)
                 foreach (Match match in Regex.Matches(resolutions, @"(?<horizontal>\d+)"+@"(?:x)"+@"(?<vertical>\d+)"))
                 {   
                     var width = Int32.Parse(match.Groups["horizontal"].Value);
                     var height = Int32.Parse(match.Groups["vertical"].Value); 
                     yield return (width, height);
                 } 
-    
         }
 
         public static IEnumerable<string> InnerText(string html, string tag)
         {
-            throw new NotImplementedException();
+            var temp = "(?<tag>"+tag+")";   
+            string pattern = @"(?:<"+temp+".*?)(?<=>)(?:<.+>)*(?<text>.*?)(?:</.+>)*(?=</\\k<tag>)";  
+            foreach (Match match in Regex.Matches(html, pattern)) 
+            {
+                yield return match.Groups["text"].Value;
+            }
         }
     
     }

--- a/Assignment1/Assignment1/RegExpr.cs
+++ b/Assignment1/Assignment1/RegExpr.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using System;
 using System.Collections.Generic;
 
@@ -7,7 +8,13 @@ namespace Assignment1
     {
         public static IEnumerable<string> SplitLine(IEnumerable<string> lines)
         {
-            throw new NotImplementedException();
+            foreach (var line in lines)
+            {
+                foreach (var word in Regex.Split(line, @"\W"))
+                {
+                    yield return word; 
+                } 
+            }
         }
 
         public static IEnumerable<(int width, int height)> Resolution(string resolutions)

--- a/Assignment1/Assignment1/RegExpr.cs
+++ b/Assignment1/Assignment1/RegExpr.cs
@@ -22,20 +22,19 @@ namespace Assignment1
         public static IEnumerable<(int width, int height)> Resolution(string resolutions)
         {
             //(?<vertical>\d+)(?:x)(?<horizontal>\d+)
-            foreach (var line in resolutions)
-            {
-                foreach (var word in Regex.Matches(line, @"(?<horizontal>\d+)(?:x)(?<vertical>\d+)"))
-                {
-                    Console.WriteLine(word);
-                    yield return Int32.Parse(word);
-                    //yield return word;
+                foreach (Match match in Regex.Matches(resolutions, @"(?<horizontal>\d+)"+@"(?:x)"+@"(?<vertical>\d+)"))
+                {   
+                    var width = Int32.Parse(match.Groups["horizontal"].Value);
+                    var height = Int32.Parse(match.Groups["vertical"].Value); 
+                    yield return (width, height);
                 } 
-            }
+    
         }
 
         public static IEnumerable<string> InnerText(string html, string tag)
         {
             throw new NotImplementedException();
         }
+    
     }
 }


### PR DESCRIPTION
Instead of catching nested tags in the regex, we replace them with the empty string hereby removing them from the yielded result.

Also fix the yml file to refer to the correct folder so that checks pass.