### PR TITLE
Innertext regex replace

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           dotnet version: 5.0.x
       - name: Install dependencies
-        run: dotnet restore
+        run: dotnet restore ./Assignment1/
       - name: Build 
         run: dotnet build --configuration Release --no-restore
       - name: Test

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -20,6 +20,6 @@ jobs:
       - name: Install dependencies
         run: dotnet restore ./Assignment1/
       - name: Build 
-        run: dotnet build --configuration Release --no-restore
+        run: dotnet build --configuration Release --no-restore ./Assignment1/
       - name: Test
-        run: dotnet test --no-restore --verbosity normal
+        run: dotnet test --no-restore --verbosity normal ./Assignment1/

--- a/Assignment1/Assignment1/RegExpr.cs
+++ b/Assignment1/Assignment1/RegExpr.cs
@@ -35,7 +35,7 @@ namespace Assignment1
             string pattern = @"(?:<"+temp+".*?)(?<=>)(?:<.+>)*(?<text>.*?)(?:</.+>)*(?=</\\k<tag>)";  
             foreach (Match match in Regex.Matches(html, pattern)) 
             {
-                yield return match.Groups["text"].Value;
+                yield return Regex.Replace(match.Groups["text"].Value, @"(<.+?>)", "");
             }
         }
     


### PR DESCRIPTION
Instead of catching nested tags in the regex, we replace them with the empty string hereby removing them from the yielded result.

Also fix the yml file to refer to the correct folder so that checks pass.